### PR TITLE
Add web support

### DIFF
--- a/crates/bevy_pbr/src/light_probe/copy.wgsl
+++ b/crates/bevy_pbr/src/light_probe/copy.wgsl
@@ -7,7 +7,7 @@
 
 @compute
 @workgroup_size(8, 8, 1)
-fn copy_mip0(@builtin(global_invocation_id) global_id: vec3u) {
+fn copy(@builtin(global_invocation_id) global_id: vec3u) {
     let size = textureDimensions(src_cubemap).xy;
 
     // Bounds check

--- a/crates/bevy_pbr/src/light_probe/downsample.wgsl
+++ b/crates/bevy_pbr/src/light_probe/downsample.wgsl
@@ -1,29 +1,43 @@
 // Single pass downsampling shader for creating the mip chain for an array texture
 // Ported from https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/c16b1d286b5b438b75da159ab51ff426bacea3d1/sdk/include/FidelityFX/gpu/spd/ffx_spd.h
 
+@group(0) @binding(0) var sampler_linear_clamp: sampler;
+@group(0) @binding(1) var<uniform> constants: Constants;
+#ifdef COMBINE_BIND_GROUP
+@group(0) @binding(2) var mip_0: texture_2d_array<f32>;
+@group(0) @binding(3) var mip_1: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(4) var mip_2: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(5) var mip_3: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(6) var mip_4: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(7) var mip_5: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(8) var mip_6: texture_storage_2d_array<rgba16float, read_write>;
+@group(0) @binding(9) var mip_7: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(10) var mip_8: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(11) var mip_9: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(12) var mip_10: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(13) var mip_11: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(14) var mip_12: texture_storage_2d_array<rgba16float, write>;
+#endif
+
 #ifdef FIRST_PASS
-// First pass bindings (mip0 -> mips 1-6)
-@group(0) @binding(0) var mip_0: texture_2d_array<f32>;
-@group(0) @binding(1) var mip_1: texture_storage_2d_array<rgba16float, write>;
-@group(0) @binding(2) var mip_2: texture_storage_2d_array<rgba16float, write>;
-@group(0) @binding(3) var mip_3: texture_storage_2d_array<rgba16float, write>;
-@group(0) @binding(4) var mip_4: texture_storage_2d_array<rgba16float, write>;
-@group(0) @binding(5) var mip_5: texture_storage_2d_array<rgba16float, write>;
-@group(0) @binding(6) var mip_6: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(2) var mip_0: texture_2d_array<f32>;
+@group(0) @binding(3) var mip_1: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(4) var mip_2: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(5) var mip_3: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(6) var mip_4: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(7) var mip_5: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(8) var mip_6: texture_storage_2d_array<rgba16float, write>;
 #endif
 
 #ifdef SECOND_PASS
-// Second pass bindings (mip6 -> mips 7-12)
-@group(0) @binding(0) var mip_6_in: texture_2d_array<f32>;
-@group(0) @binding(1) var mip_7: texture_storage_2d_array<rgba16float, write>;
-@group(0) @binding(2) var mip_8: texture_storage_2d_array<rgba16float, write>;
-@group(0) @binding(3) var mip_9: texture_storage_2d_array<rgba16float, write>;
-@group(0) @binding(4) var mip_10: texture_storage_2d_array<rgba16float, write>;
-@group(0) @binding(5) var mip_11: texture_storage_2d_array<rgba16float, write>;
-@group(0) @binding(6) var mip_12: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(2) var mip_6: texture_2d_array<f32>;
+@group(0) @binding(3) var mip_7: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(4) var mip_8: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(5) var mip_9: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(6) var mip_10: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(7) var mip_11: texture_storage_2d_array<rgba16float, write>;
+@group(0) @binding(8) var mip_12: texture_storage_2d_array<rgba16float, write>;
 #endif
-@group(0) @binding(7) var sampler_linear_clamp: sampler;
-@group(0) @binding(8) var<uniform> constants: Constants;
 
 struct Constants { mips: u32, inverse_input_size: vec2f }
 
@@ -317,12 +331,16 @@ fn remap_for_wave_reduction(a: u32) -> vec2u {
 
 fn spd_reduce_load_source_image(uv: vec2u, slice: u32) -> vec4f {
     let texture_coord = (vec2f(uv) + 0.5) * constants.inverse_input_size;
-    
-#ifdef FIRST_PASS
+
+    #ifdef COMBINE_BIND_GROUP
     let result = textureSampleLevel(mip_0, sampler_linear_clamp, texture_coord, slice, 0.0);
-#else
-    let result = textureSampleLevel(mip_6_in, sampler_linear_clamp, texture_coord, slice, 0.0);
-#endif
+    #endif
+    #ifdef FIRST_PASS
+    let result = textureSampleLevel(mip_0, sampler_linear_clamp, texture_coord, slice, 0.0);
+    #endif
+    #ifdef SECOND_PASS
+    let result = textureSampleLevel(mip_6, sampler_linear_clamp, texture_coord, slice, 0.0);
+    #endif
 
 #ifdef SRGB_CONVERSION
     return vec4(
@@ -339,30 +357,39 @@ fn spd_reduce_load_source_image(uv: vec2u, slice: u32) -> vec4f {
 
 fn spd_store(pix: vec2u, value: vec4f, mip: u32, slice: u32) {
     if mip >= constants.mips { return; }
-#ifdef FIRST_PASS
     switch mip {
+        #ifdef COMBINE_BIND_GROUP
         case 0u: { textureStore(mip_1, pix, slice, value); }
         case 1u: { textureStore(mip_2, pix, slice, value); }
         case 2u: { textureStore(mip_3, pix, slice, value); }
         case 3u: { textureStore(mip_4, pix, slice, value); }
         case 4u: { textureStore(mip_5, pix, slice, value); }
         case 5u: { textureStore(mip_6, pix, slice, value); }
-        default: {}
-    }
-#endif
-#ifdef SECOND_PASS
-    // In second pass, mip 6 is read-only, so we only write to mips 7-12
-    // Adjust mip level by 1 since we're not writing to mip 6
-    switch mip {
         case 6u: { textureStore(mip_7, pix, slice, value); }
         case 7u: { textureStore(mip_8, pix, slice, value); }
         case 8u: { textureStore(mip_9, pix, slice, value); }
         case 9u: { textureStore(mip_10, pix, slice, value); }
         case 10u: { textureStore(mip_11, pix, slice, value); }
         case 11u: { textureStore(mip_12, pix, slice, value); }
+        #endif
+        #ifdef FIRST_PASS
+        case 0u: { textureStore(mip_1, pix, slice, value); }
+        case 1u: { textureStore(mip_2, pix, slice, value); }
+        case 2u: { textureStore(mip_3, pix, slice, value); }
+        case 3u: { textureStore(mip_4, pix, slice, value); }
+        case 4u: { textureStore(mip_5, pix, slice, value); }
+        case 5u: { textureStore(mip_6, pix, slice, value); }
+        #endif
+        #ifdef SECOND_PASS
+        case 6u: { textureStore(mip_7, pix, slice, value); }
+        case 7u: { textureStore(mip_8, pix, slice, value); }
+        case 8u: { textureStore(mip_9, pix, slice, value); }
+        case 9u: { textureStore(mip_10, pix, slice, value); }
+        case 10u: { textureStore(mip_11, pix, slice, value); }
+        case 11u: { textureStore(mip_12, pix, slice, value); }
+        #endif
         default: {}
     }
-#endif
 }
 
 fn spd_store_intermediate(x: u32, y: u32, value: vec4f) {
@@ -385,16 +412,23 @@ fn spd_reduce_intermediate(i0: vec2u, i1: vec2u, i2: vec2u, i3: vec2u) -> vec4f 
 }
 
 fn spd_reduce_load_4(i0: vec2u, i1: vec2u, i2: vec2u, i3: vec2u, slice: u32) -> vec4f {
-#ifdef SECOND_PASS
-    let v0 = textureLoad(mip_6_in, i0, slice, 0);
-    let v1 = textureLoad(mip_6_in, i1, slice, 0);
-    let v2 = textureLoad(mip_6_in, i2, slice, 0);
-    let v3 = textureLoad(mip_6_in, i3, slice, 0);
+    #ifdef COMBINE_BIND_GROUP
+    let v0 = textureLoad(mip_6, i0, slice);
+    let v1 = textureLoad(mip_6, i1, slice);
+    let v2 = textureLoad(mip_6, i2, slice);
+    let v3 = textureLoad(mip_6, i3, slice);
     return spd_reduce_4(v0, v1, v2, v3);
-#else
-    // Not used in first pass
-    return vec4(0.0);
-#endif
+    #endif
+    #ifdef FIRST_PASS
+    return vec4(0.0, 0.0, 0.0, 0.0);
+    #endif
+    #ifdef SECOND_PASS
+    let v0 = textureLoad(mip_6, i0, slice, 0);
+    let v1 = textureLoad(mip_6, i1, slice, 0);
+    let v2 = textureLoad(mip_6, i2, slice, 0);
+    let v3 = textureLoad(mip_6, i3, slice, 0);
+    return spd_reduce_4(v0, v1, v2, v3);
+    #endif
 }
 
 fn spd_reduce_4(v0: vec4f, v1: vec4f, v2: vec4f, v3: vec4f) -> vec4f {

--- a/crates/bevy_pbr/src/light_probe/generate.rs
+++ b/crates/bevy_pbr/src/light_probe/generate.rs
@@ -603,7 +603,7 @@ pub fn prepare_generated_environment_map_bind_groups(
                     ..Default::default()
                 });
 
-                // Split layout (current behaviour)
+                // Split layout (current behavior)
                 let first = render_device.create_bind_group(
                     "downsampling_first_bind_group",
                     &layouts.downsampling_first,

--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -305,7 +305,7 @@ impl Plugin for LightProbePlugin {
 
         embedded_asset!(app, "environment_filter.wgsl");
         embedded_asset!(app, "downsample.wgsl");
-        embedded_asset!(app, "copy_mip0.wgsl");
+        embedded_asset!(app, "copy.wgsl");
 
         app.add_plugins(ExtractInstancesPlugin::<EnvironmentMapIds>::new())
             .add_plugins(SyncComponentPlugin::<GeneratedEnvironmentMapLight>::default())


### PR DESCRIPTION
## Goal

Unblock CI for https://github.com/bevyengine/bevy/pull/19076
and add web support.

## Summary

WebGPU browsers implement the same feature set as native **except** for a few hard limits and format caveats that do not show up on Vulkan/DX12 back-ends.  This patch makes the light-probe mip-chain generator run everywhere by respecting those limits.

**Runtime feature detection**

At startup we inspect the adapter:

* `limits.max_storage_textures_per_shader_stage` – must be ≥ 12, **and**
* `TextureFormatFeatureFlags::STORAGE_READ_WRITE` for `RGBA16F` – indicates the backend supports read–write storage on that format.

If *both* are true we enable the **combined layout**: one bind group reused for both compute passes, with `mip-6` bound as `read_write`.

Otherwise we fall back to the **dual-layout** path: two bind groups (mips 1-6 / 7-12) with `mip-6` sampled read-only.  This satisfies WebGPU’s 8-writable-textures limit and its prohibition on `read_write` RGBA16F.

**Shader variants (the `#ifdef` blocks)**

WebGPU 1.0 allows at most eight writable storage textures per shader *stage* and counts the limit at **pipeline-creation** time, irrespective of how many bindings the application sets later.  The down-sampler needs twelve mips, so the work is split into two passes and each pass is compiled with different `ShaderDef`s (`FIRST_PASS` and `SECOND_PASS`).  Each compiled module therefore declares only six `texture_storage_*` bindings and passes validation.

**Separate CPU-side bind groups**

Because the limit is per stage, not per bind group, each compute pipeline still has to expose no more than eight writable storage textures.  That means the CPU must build two distinct bind groups that match the two shader layouts: one for mips 1-6 and a second one for mips 7-12 (plus the read-only view of mip 6).  A single 13-binding layout would be rejected by browsers even if half the bindings stay unused.

**Placeholder textures to avoid aliasing**

WebGPU forbids aliasing two writable bindings that refer to the **same** sub-resource in the same pass.  When the source cubemap is small (for example 256², only nine real mips) several of the requested views would collapse onto the same last mip and the validator reports “writable storage texture binding aliasing”.  The fix is to provide a unique 1 × 1 × 6 RGBA16F placeholder texture whenever a requested mip is beyond `last_mip`.  Each placeholder is a distinct sub-resource, so no aliasing occurs.

**Why mip 6 is split into read- and write-only views**

RGBA16F cannot be bound as `read_write` storage in compute on WebGPU; only *write-only* or *read-only* is allowed.  The SPD algorithm still needs to sample from mip 6 while it writes the same level in the second pass, so the pipeline is arranged as

* first pass: write mip 6 (write-only binding)
* second pass: sample mip 6 (read-only sampled-texture binding) and write mips 7-12 (write-only bindings)

This keeps every binding within the format-usage rules.

**Entry-point naming quirk**

Some WebGPU runtimes reject entry points whose names end in a naked digit (e.g. `copy0`).  All new entry points were therefore given non-numeric suffixes (`copy`, `downsample_first`, `downsample_second`) to avoid the issue. 

## Showcase

<img width="1728" height="1117" alt="Screenshot 2025-07-22 at 1 37 21 AM" src="https://github.com/user-attachments/assets/0845e240-05aa-4148-8558-1b3ec6ef796e" />


## Testing

```bash
bevy run --example reflection_probes --features webgpu web
info: compiling to WebAssembly...
   Compiling bevy v0.17.0-dev
    Finished `web` profile [unoptimized + debuginfo] target(s) in 5.56s
info: bundling JavaScript bindings...
info: no custom `web` folder found, using defaults.
info: open your app at <http://localhost:4000>!
```