### PR TITLE
WIP: Render pipeline specialization pass mesh bindings

### DIFF
--- a/crates/bevy_pbr/src/atmosphere/bindings.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/bindings.wgsl
@@ -7,21 +7,21 @@
     atmosphere::types::{Atmosphere, AtmosphereSettings, AtmosphereTransforms}
 }
 
-@group(0) @binding(0) var<uniform> atmosphere: Atmosphere;
-@group(0) @binding(1) var<uniform> settings: AtmosphereSettings;
-@group(0) @binding(2) var<uniform> atmosphere_transforms: AtmosphereTransforms;
-@group(0) @binding(3) var<uniform> view: View;
-@group(0) @binding(4) var<uniform> lights: Lights;
-@group(0) @binding(5) var transmittance_lut: texture_2d<f32>;
-@group(0) @binding(6) var transmittance_lut_sampler: sampler;
-@group(0) @binding(7) var multiscattering_lut: texture_2d<f32>;
-@group(0) @binding(8) var multiscattering_lut_sampler: sampler;
-@group(0) @binding(9) var sky_view_lut: texture_2d<f32>;
-@group(0) @binding(10) var sky_view_lut_sampler: sampler;
-@group(0) @binding(11) var aerial_view_lut: texture_3d<f32>;
-@group(0) @binding(12) var aerial_view_lut_sampler: sampler;
-@group(0) @binding(14) var directional_shadow_texture: texture_depth_2d_array;
-@group(0) @binding(15) var directional_shadow_sampler: sampler_comparison;
-@group(0) @binding(16) var blue_noise_texture: texture_2d_array<f32>;
-@group(0) @binding(17) var blue_noise_sampler: sampler;
-@group(0) @binding(18) var<uniform> probe_transform_buffer: mat4x4<f32>;
+@group(1) @binding(0) var<uniform> atmosphere: Atmosphere;
+@group(1) @binding(1) var<uniform> settings: AtmosphereSettings;
+@group(1) @binding(2) var<uniform> atmosphere_transforms: AtmosphereTransforms;
+@group(1) @binding(3) var<uniform> view: View;
+@group(1) @binding(4) var<uniform> lights: Lights;
+@group(1) @binding(5) var transmittance_lut: texture_2d<f32>;
+@group(1) @binding(6) var transmittance_lut_sampler: sampler;
+@group(1) @binding(7) var multiscattering_lut: texture_2d<f32>;
+@group(1) @binding(8) var multiscattering_lut_sampler: sampler;
+@group(1) @binding(9) var sky_view_lut: texture_2d<f32>;
+@group(1) @binding(10) var sky_view_lut_sampler: sampler;
+@group(1) @binding(11) var aerial_view_lut: texture_3d<f32>;
+@group(1) @binding(12) var aerial_view_lut_sampler: sampler;
+@group(1) @binding(14) var directional_shadow_texture: texture_depth_2d_array;
+@group(1) @binding(15) var directional_shadow_sampler: sampler_comparison;
+@group(1) @binding(16) var blue_noise_texture: texture_2d_array<f32>;
+@group(1) @binding(17) var blue_noise_sampler: sampler;
+@group(1) @binding(18) var<uniform> probe_transform_buffer: mat4x4<f32>;

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -45,7 +45,7 @@ use bevy_ecs::{
     schedule::IntoScheduleConfigs,
     system::Query,
 };
-use bevy_light::{DirectionalLight};
+use bevy_light::DirectionalLight;
 use bevy_math::{UVec2, UVec3, Vec3};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
@@ -66,7 +66,7 @@ use bevy_core_pipeline::core_3d::{graph::Core3d, Camera3d};
 use bevy_transform::components::Transform;
 use resources::{
     prepare_atmosphere_transforms, queue_render_sky_pipelines, AtmosphereTransforms,
-    RenderSkyBindGroupLayouts,
+    RenderSkyPipeline,
 };
 use tracing::warn;
 
@@ -138,11 +138,11 @@ impl Plugin for AtmospherePlugin {
 
         render_app
             .init_resource::<AtmosphereBindGroupLayouts>()
-            .init_resource::<RenderSkyBindGroupLayouts>()
+            .init_resource::<RenderSkyPipeline>()
             .init_resource::<AtmosphereSamplers>()
             .init_resource::<AtmospherePipelines>()
             .init_resource::<AtmosphereTransforms>()
-            .init_resource::<SpecializedRenderPipelines<RenderSkyBindGroupLayouts>>()
+            .init_resource::<SpecializedRenderPipelines<RenderSkyPipeline>>()
             .init_resource::<AtmosphereBuffer>()
             .add_systems(
                 Render,

--- a/crates/bevy_pbr/src/atmosphere/node.rs
+++ b/crates/bevy_pbr/src/atmosphere/node.rs
@@ -12,7 +12,11 @@ use bevy_render::{
     view::{ViewTarget, ViewUniformOffset},
 };
 
-use crate::{resources::{AtmosphereEnvironmentMap, AtmosphereProbeBindGroups}, ViewLightsUniformOffset};
+use crate::{
+    resources::{AtmosphereEnvironmentMap, AtmosphereProbeBindGroups},
+    MeshViewBindGroup, ViewEnvironmentMapUniformOffset, ViewFogUniformOffset,
+    ViewLightProbesUniformOffset, ViewLightsUniformOffset, ViewScreenSpaceReflectionsUniformOffset,
+};
 
 use super::{
     resources::{
@@ -92,7 +96,7 @@ impl ViewNode for AtmosphereLutsNode {
 
         luts_pass.set_pipeline(transmittance_lut_pipeline);
         luts_pass.set_bind_group(
-            0,
+            1,
             &bind_groups.transmittance_lut,
             &[
                 atmosphere_uniforms_offset.index(),
@@ -106,7 +110,7 @@ impl ViewNode for AtmosphereLutsNode {
 
         luts_pass.set_pipeline(multiscattering_lut_pipeline);
         luts_pass.set_bind_group(
-            0,
+            1,
             &bind_groups.multiscattering_lut,
             &[
                 atmosphere_uniforms_offset.index(),
@@ -124,7 +128,7 @@ impl ViewNode for AtmosphereLutsNode {
 
         luts_pass.set_pipeline(sky_view_lut_pipeline);
         luts_pass.set_bind_group(
-            0,
+            1,
             &bind_groups.sky_view_lut,
             &[
                 atmosphere_uniforms_offset.index(),
@@ -141,7 +145,7 @@ impl ViewNode for AtmosphereLutsNode {
 
         luts_pass.set_pipeline(aerial_view_lut_pipeline);
         luts_pass.set_bind_group(
-            0,
+            1,
             &bind_groups.aerial_view_lut,
             &[
                 atmosphere_uniforms_offset.index(),
@@ -171,6 +175,13 @@ impl ViewNode for RenderSkyNode {
         Read<ViewUniformOffset>,
         Read<ViewLightsUniformOffset>,
         Read<RenderSkyPipelineId>,
+        Read<MeshViewBindGroup>,
+        Read<ViewUniformOffset>,
+        Read<ViewLightsUniformOffset>,
+        Read<ViewFogUniformOffset>,
+        Read<ViewLightProbesUniformOffset>,
+        Read<ViewScreenSpaceReflectionsUniformOffset>,
+        Read<ViewEnvironmentMapUniformOffset>,
     );
 
     fn run<'w>(
@@ -186,6 +197,13 @@ impl ViewNode for RenderSkyNode {
             view_uniforms_offset,
             lights_uniforms_offset,
             render_sky_pipeline_id,
+            view_bind_group,
+            view_uniform_offset,
+            view_lights_offset,
+            view_fog_offset,
+            view_light_probes_offset,
+            view_ssr_offset,
+            view_environment_map_offset,
         ): QueryItem<'w, '_, Self::ViewQuery>,
         world: &'w World,
     ) -> Result<(), NodeRunError> {
@@ -210,6 +228,18 @@ impl ViewNode for RenderSkyNode {
         render_sky_pass.set_pipeline(render_sky_pipeline);
         render_sky_pass.set_bind_group(
             0,
+            &view_bind_group.main,
+            &[
+                view_uniform_offset.offset,
+                view_lights_offset.offset,
+                view_fog_offset.offset,
+                **view_light_probes_offset,
+                **view_ssr_offset,
+                **view_environment_map_offset,
+            ],
+        );
+        render_sky_pass.set_bind_group(
+            1,
             &atmosphere_bind_groups.render_sky,
             &[
                 atmosphere_uniforms_offset.index(),
@@ -219,7 +249,7 @@ impl ViewNode for RenderSkyNode {
                 lights_uniforms_offset.offset,
             ],
         );
-        render_sky_pass.draw(0..3, 0..1);
+        render_sky_pass.draw(0..2, 0..1);
 
         Ok(())
     }
@@ -291,7 +321,7 @@ impl Node for EnvironmentNode {
 
             pass.set_pipeline(environment_pipeline);
             pass.set_bind_group(
-                0,
+                1,
                 &bind_groups.environment,
                 &[
                     atmosphere_uniforms_offset.index(),

--- a/crates/bevy_pbr/src/atmosphere/node.rs
+++ b/crates/bevy_pbr/src/atmosphere/node.rs
@@ -249,7 +249,7 @@ impl ViewNode for RenderSkyNode {
                 lights_uniforms_offset.offset,
             ],
         );
-        render_sky_pass.draw(0..2, 0..1);
+        render_sky_pass.draw(0..3, 0..1);
 
         Ok(())
     }

--- a/crates/bevy_pbr/src/atmosphere/types.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/types.wgsl
@@ -48,7 +48,7 @@ struct AtmosphereTransforms {
     atmosphere_from_world: mat4x4<f32>,
 }
 
-struct PbrAtmosphereData {
+struct AtmosphereData {
     atmosphere: Atmosphere,
     settings: AtmosphereSettings,
 }

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -45,7 +45,7 @@ use crate::{
         IRRADIANCE_VOLUMES_ARE_USABLE,
     },
     prepass,
-    resources::{AtmosphereBuffer, AtmosphereSamplers, AtmosphereTextures, PbrAtmosphereData},
+    resources::{AtmosphereBuffer, AtmosphereData, AtmosphereSamplers, AtmosphereTextures},
     Atmosphere, EnvironmentMapUniformBuffer, FogMeta, GlobalClusterableObjectMeta,
     GpuClusterableObjects, GpuFog, GpuLights, LightMeta, LightProbesBuffer, LightProbesUniform,
     MeshPipeline, MeshPipelineKey, RenderViewLightProbes, ScreenSpaceAmbientOcclusionResources,
@@ -407,7 +407,7 @@ fn layout_entries(
             ),
             (30, sampler(SamplerBindingType::Filtering)),
             // atmosphere data buffer
-            (31, storage_buffer_read_only::<PbrAtmosphereData>(false)),
+            (31, storage_buffer_read_only::<AtmosphereData>(false)),
         ));
     }
 

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -98,7 +98,7 @@ const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: u32 = 64u;
 #ifdef ATMOSPHERE
 @group(0) @binding(29) var atmosphere_transmittance_texture: texture_2d<f32>;
 @group(0) @binding(30) var atmosphere_transmittance_sampler: sampler;
-@group(0) @binding(31) var<storage> atmosphere_data: atmosphere::PbrAtmosphereData;
+@group(0) @binding(31) var<storage> atmosphere_data: atmosphere::AtmosphereData;
 #endif // ATMOSPHERE
 
 #ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY


### PR DESCRIPTION
I am digging into reusing the shadow functions in the atmosphere pipeline and here is my conclusion. 
- Examine the way volumetric fog is implemented with the pipeline specialization
- use bind group 1 instead of group 0 in the atmosphere pipeline
- try binding the mesh view bind group to group 0 for the atmosphere pipeline, just like the volumetric fog pipeline during pipeline specialization
- the dynamic uniforms limit has to be at or below 8, at the moment there are 11:
  - Remove view and lights since those are now coming from the mesh view bind group
  - Move atmosphere transforms into PbrAtmosphereData , rename to AtmosphereData
  - Use the AtmosphereData as a storage buffer instead of uniform, both in the atmosphere pipelines and the mesh pipeline