### PR TITLE
WIP: Atmosphere as entity with transform

### DIFF
--- a/crates/bevy_light/src/atmosphere.rs
+++ b/crates/bevy_light/src/atmosphere.rs
@@ -2,25 +2,36 @@
 
 use alloc::{borrow::Cow, sync::Arc};
 use bevy_asset::{Asset, AssetEvent, AssetId, Handle};
-use bevy_camera::Hdr;
 use bevy_color::{ColorToComponents, Gray, LinearRgba};
 use bevy_ecs::{
     component::Component,
+    lifecycle::HookContext,
     message::MessageReader,
     system::{Res, ResMut},
+    world::DeferredWorld,
 };
 use bevy_image::Image;
 use bevy_math::curve::{FunctionCurve, Interval, SampleAutoCurve};
 use bevy_math::{ops, Curve, FloatPow, Vec3};
 use bevy_platform::collections::HashSet;
 use bevy_reflect::TypePath;
+use bevy_transform::components::Transform;
 use core::f32::{self, consts::PI};
 use smallvec::SmallVec;
 use wgpu_types::TextureFormat;
 
-/// Enables atmospheric scattering for an HDR camera.
+/// Atmosphere for one planet. The entity's [`Transform`] is the planet center in world space.
+///
+/// Add `AtmosphereSettings` to each 3D camera that should use it, the nearest atmosphere is used for rendering.
+///
+/// If [`Transform`] is still [`Default`] when this component is first added, it is placed for a Y-up
+/// frame with the planet's north pole toward world +Y. Set your own transform for anything else.
+///
+/// The scale on [`Transform`] rescales the planet in world space. Tune it with the radius offset
+/// when your scene uses other units, like kilometer-sized scenes.
 #[derive(Clone, Component)]
-#[require(Hdr)]
+#[require(Transform::default())]
+#[component(on_add = set_default_transform)]
 pub struct Atmosphere {
     /// Radius of the planet
     ///
@@ -42,6 +53,22 @@ pub struct Atmosphere {
     /// A handle to a [`ScatteringMedium`], which describes the substance
     /// of the atmosphere and how it scatters light.
     pub medium: Handle<ScatteringMedium>,
+}
+
+fn set_default_transform(mut world: DeferredWorld<'_>, HookContext { entity, .. }: HookContext) {
+    let Some(bottom_radius) = world
+        .entity(entity)
+        .get::<Atmosphere>()
+        .map(|a| a.bottom_radius)
+    else {
+        return;
+    };
+
+    if let Some(mut transform) = world.get_mut::<Transform>(entity) {
+        if *transform == Transform::default() {
+            transform.translation = -Vec3::Y * bottom_radius;
+        }
+    }
 }
 
 impl Atmosphere {

--- a/crates/bevy_light/src/atmosphere.rs
+++ b/crates/bevy_light/src/atmosphere.rs
@@ -15,7 +15,7 @@ use bevy_math::curve::{FunctionCurve, Interval, SampleAutoCurve};
 use bevy_math::{ops, Curve, FloatPow, Vec3};
 use bevy_platform::collections::HashSet;
 use bevy_reflect::TypePath;
-use bevy_transform::components::Transform;
+use bevy_transform::components::GlobalTransform;
 use core::f32::{self, consts::PI};
 use smallvec::SmallVec;
 use wgpu_types::TextureFormat;
@@ -29,7 +29,7 @@ use wgpu_types::TextureFormat;
 /// The scale on [`Transform`] rescales the planet in world space. Tune it with the radius offset
 /// when your scene uses other units, like kilometer-sized scenes.
 #[derive(Clone, Component)]
-#[require(Transform::default())]
+#[require(GlobalTransform::default())]
 #[component(on_add = set_default_transform)]
 pub struct Atmosphere {
     /// Radius of the planet
@@ -55,17 +55,14 @@ pub struct Atmosphere {
 }
 
 fn set_default_transform(mut world: DeferredWorld<'_>, HookContext { entity, .. }: HookContext) {
-    let Some(bottom_radius) = world
-        .get::<Atmosphere>(entity)
-        .map(|a| a.bottom_radius)
-    else {
+    let Some(bottom_radius) = world.get::<Atmosphere>(entity).map(|a| a.bottom_radius) else {
         unreachable!("on_add hooks guarantee the component is present");
     };
 
-    if let Some(mut transform) = world.get_mut::<Transform>(entity)
-        && *transform == Transform::default()
+    if let Some(mut transform) = world.get_mut::<GlobalTransform>(entity)
+        && *transform == GlobalTransform::default()
     {
-        transform.translation = -Vec3::Y * bottom_radius;
+        *transform = GlobalTransform::from_translation(-Vec3::Y * bottom_radius);
     }
 }
 

--- a/crates/bevy_light/src/atmosphere.rs
+++ b/crates/bevy_light/src/atmosphere.rs
@@ -64,10 +64,10 @@ fn set_default_transform(mut world: DeferredWorld<'_>, HookContext { entity, .. 
         return;
     };
 
-    if let Some(mut transform) = world.get_mut::<Transform>(entity) {
-        if *transform == Transform::default() {
-            transform.translation = -Vec3::Y * bottom_radius;
-        }
+    if let Some(mut transform) = world.get_mut::<Transform>(entity)
+        && *transform == Transform::default()
+    {
+        transform.translation = -Vec3::Y * bottom_radius;
     }
 }
 

--- a/crates/bevy_light/src/atmosphere.rs
+++ b/crates/bevy_light/src/atmosphere.rs
@@ -24,8 +24,7 @@ use wgpu_types::TextureFormat;
 ///
 /// Add `AtmosphereSettings` to each 3D camera that should use it, the nearest atmosphere is used for rendering.
 ///
-/// If [`Transform`] is still [`Default`] when this component is first added, it is placed for a Y-up
-/// frame with the planet's north pole toward world +Y. Set your own transform for anything else.
+/// If [`Transform`] is still [`Default`] when this component is first added, it is placed `radius` units directly below the origin on the `Y` axis, so that the planet's normal is roughly `Vec3::Y` around the origin, likely where your camera/scene is located. Unless you're making a game set in space, this is probably what you want. Otherwise, feel free to override this default by setting a transform manually.
 ///
 /// The scale on [`Transform`] rescales the planet in world space. Tune it with the radius offset
 /// when your scene uses other units, like kilometer-sized scenes.
@@ -57,11 +56,10 @@ pub struct Atmosphere {
 
 fn set_default_transform(mut world: DeferredWorld<'_>, HookContext { entity, .. }: HookContext) {
     let Some(bottom_radius) = world
-        .entity(entity)
-        .get::<Atmosphere>()
+        .get::<Atmosphere>(entity)
         .map(|a| a.bottom_radius)
     else {
-        return;
+        unreachable!("on_add hooks guarantee the component is present");
     };
 
     if let Some(mut transform) = world.get_mut::<Transform>(entity)

--- a/crates/bevy_light/src/atmosphere.rs
+++ b/crates/bevy_light/src/atmosphere.rs
@@ -20,13 +20,13 @@ use core::f32::{self, consts::PI};
 use smallvec::SmallVec;
 use wgpu_types::TextureFormat;
 
-/// Atmosphere for one planet. The entity's [`Transform`] is the planet center in world space.
+/// Atmosphere for one planet. The entity's [`GlobalTransform`] is the planet center in world space.
 ///
 /// Add `AtmosphereSettings` to each 3D camera that should use it, the nearest atmosphere is used for rendering.
 ///
-/// If [`Transform`] is still [`Default`] when this component is first added, it is placed `radius` units directly below the origin on the `Y` axis, so that the planet's normal is roughly `Vec3::Y` around the origin, likely where your camera/scene is located. Unless you're making a game set in space, this is probably what you want. Otherwise, feel free to override this default by setting a transform manually.
+/// If [`GlobalTransform`] is still [`Default`] when this component is first added, it is placed `radius` units directly below the origin on the `Y` axis, so that the planet's normal is roughly `Vec3::Y` around the origin, likely where your camera/scene is located. Unless you're making a game set in space, this is probably what you want. Otherwise, feel free to override this default by setting a transform manually.
 ///
-/// The scale on [`Transform`] rescales the planet in world space. Tune it with the radius offset
+/// The scale on [`GlobalTransform`] rescales the planet in world space. Tune it with the radius offset
 /// when your scene uses other units, like kilometer-sized scenes.
 #[derive(Clone, Component)]
 #[require(GlobalTransform::default())]

--- a/crates/bevy_light/src/atmosphere.rs
+++ b/crates/bevy_light/src/atmosphere.rs
@@ -35,13 +35,13 @@ pub struct Atmosphere {
     /// Radius of the planet
     ///
     /// units: m
-    pub bottom_radius: f32,
+    pub inner_radius: f32,
 
     /// Radius at which we consider the atmosphere to 'end' for our
     /// calculations (from center of planet)
     ///
     /// units: m
-    pub top_radius: f32,
+    pub outer_radius: f32,
 
     /// An approximation of the average albedo (or color, roughly) of the
     /// planet's surface. This is used when calculating multiscattering.
@@ -55,26 +55,26 @@ pub struct Atmosphere {
 }
 
 fn set_default_transform(mut world: DeferredWorld<'_>, HookContext { entity, .. }: HookContext) {
-    let Some(bottom_radius) = world.get::<Atmosphere>(entity).map(|a| a.bottom_radius) else {
+    let Some(inner_radius) = world.get::<Atmosphere>(entity).map(|a| a.inner_radius) else {
         unreachable!("on_add hooks guarantee the component is present");
     };
 
     if let Some(mut transform) = world.get_mut::<GlobalTransform>(entity)
         && *transform == GlobalTransform::default()
     {
-        *transform = GlobalTransform::from_translation(-Vec3::Y * bottom_radius);
+        *transform = GlobalTransform::from_translation(-Vec3::Y * inner_radius);
     }
 }
 
 impl Atmosphere {
     /// An atmosphere like that of earth. Use this with a [`ScatteringMedium::earth`] handle.
     pub fn earth(medium: Handle<ScatteringMedium>) -> Self {
-        const EARTH_BOTTOM_RADIUS: f32 = 6_360_000.0;
-        const EARTH_TOP_RADIUS: f32 = 6_460_000.0;
+        const EARTH_INNER_RADIUS: f32 = 6_360_000.0;
+        const EARTH_OUTER_RADIUS: f32 = 6_460_000.0;
         const EARTH_ALBEDO: Vec3 = Vec3::splat(0.3);
         Self {
-            bottom_radius: EARTH_BOTTOM_RADIUS,
-            top_radius: EARTH_TOP_RADIUS,
+            inner_radius: EARTH_INNER_RADIUS,
+            outer_radius: EARTH_OUTER_RADIUS,
             ground_albedo: EARTH_ALBEDO,
             medium,
         }
@@ -86,12 +86,12 @@ impl Atmosphere {
     ///
     /// [Seidelmann et al. 2007, Table 4]: https://doi.org/10.1007/s10569-007-9072-y
     pub fn mars(medium: Handle<ScatteringMedium>) -> Self {
-        const MARS_BOTTOM_RADIUS: f32 = 3_389_500.0;
-        const MARS_TOP_RADIUS: f32 = 3_509_500.0;
+        const MARS_INNER_RADIUS: f32 = 3_389_500.0;
+        const MARS_OUTER_RADIUS: f32 = 3_509_500.0;
         const MARS_ALBEDO: Vec3 = Vec3::splat(0.1);
         Self {
-            bottom_radius: MARS_BOTTOM_RADIUS,
-            top_radius: MARS_TOP_RADIUS,
+            inner_radius: MARS_INNER_RADIUS,
+            outer_radius: MARS_OUTER_RADIUS,
             ground_albedo: MARS_ALBEDO,
             medium,
         }

--- a/crates/bevy_pbr/src/atmosphere/bruneton_functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/bruneton_functions.wgsl
@@ -60,23 +60,27 @@
     bindings::atmosphere,
 }
 
+// Bruneton's paper calls the surface and exosphere "bottom radius" and "top radius".
+// Our `Atmosphere` struct uses `inner_radius` and `outer_radius` for the same values so naming stays
+// meaningful when the atmosphere entity has an arbitrary transform.
+
 // Mapping from view height (r) and zenith cos angle (mu) to UV coordinates in the transmittance LUT
 // Assuming r between ground and top atmosphere boundary, and mu= cos(zenith_angle)
 // Chosen to increase precision near the ground and to work around a discontinuity at the horizon
 // See Bruneton and Neyret 2008, "Precomputed Atmospheric Scattering" section 4
 fn transmittance_lut_r_mu_to_uv(atm: Atmosphere, r: f32, mu: f32) -> vec2<f32> {
-  // Distance along a horizontal ray from the ground to the top atmosphere boundary
-    let H = sqrt(atm.top_radius * atm.top_radius - atm.bottom_radius * atm.bottom_radius);
+    // Distance along a horizontal ray from the ground to the top atmosphere boundary
+    let H = sqrt(atm.outer_radius * atm.outer_radius - atm.inner_radius * atm.inner_radius);
 
-  // Distance from a point at height r to the horizon
-  // ignore the case where r <= atmosphere.bottom_radius
-    let rho = sqrt(max(r * r - atm.bottom_radius * atm.bottom_radius, 0.0));
+    // Distance from a point at height r to the horizon
+    // ignore the case where r <= atmosphere.inner_radius
+    let rho = sqrt(max(r * r - atm.inner_radius * atm.inner_radius, 0.0));
 
-  // Distance from a point at height r to the top atmosphere boundary at zenith angle mu
+    // Distance from a point at height r to the top atmosphere boundary at zenith angle mu
     let d = distance_to_top_atmosphere_boundary(atm, r, mu);
 
-  // Minimum and maximum distance to the top atmosphere boundary from a point at height r
-    let d_min = atm.top_radius - r; // length of the ray straight up to the top atmosphere boundary
+    // Minimum and maximum distance to the top atmosphere boundary from a point at height r
+    let d_min = atm.outer_radius - r; // length of the ray straight up to the top atmosphere boundary
     let d_max = rho + H; // length of the ray to the top atmosphere boundary and grazing the horizon
 
     let u = (d - d_min) / (d_max - d_min);
@@ -86,17 +90,17 @@ fn transmittance_lut_r_mu_to_uv(atm: Atmosphere, r: f32, mu: f32) -> vec2<f32> {
 
 // Inverse of the mapping above, mapping from UV coordinates in the transmittance LUT to view height (r) and zenith cos angle (mu)
 fn transmittance_lut_uv_to_r_mu(uv: vec2<f32>) -> vec2<f32> {
-  // Distance to top atmosphere boundary for a horizontal ray at ground level
-    let H = sqrt(atmosphere.top_radius * atmosphere.top_radius - atmosphere.bottom_radius * atmosphere.bottom_radius);
+    // Distance to top atmosphere boundary for a horizontal ray at ground level
+    let H = sqrt(atmosphere.outer_radius * atmosphere.outer_radius - atmosphere.inner_radius * atmosphere.inner_radius);
 
-  // Distance to the horizon, from which we can compute r:
+    // Distance to the horizon, from which we can compute r:
     let rho = H * uv.y;
-    let r = sqrt(rho * rho + atmosphere.bottom_radius * atmosphere.bottom_radius);
+    let r = sqrt(rho * rho + atmosphere.inner_radius * atmosphere.inner_radius);
 
-  // Distance to the top atmosphere boundary for the ray (r,mu), and its minimum
-  // and maximum values over all mu- obtained for (r,1) and (r,mu_horizon) -
-  // from which we can recover mu:
-    let d_min = atmosphere.top_radius - r;
+    // Distance to the top atmosphere boundary for the ray (r,mu), and its minimum
+    // and maximum values over all mu- obtained for (r,1) and (r,mu_horizon) -
+    // from which we can recover mu:
+    let d_min = atmosphere.outer_radius - r;
     let d_max = rho + H;
     let d = d_min + uv.x * (d_max - d_min);
 
@@ -114,26 +118,26 @@ fn transmittance_lut_uv_to_r_mu(uv: vec2<f32>) -> vec2<f32> {
 
 /// Simplified ray-sphere intersection
 /// where:
-/// Ray origin, o = [0,0,r] with r <= atmosphere.top_radius
+/// Ray origin, o = [0,0,r] with r <= atmosphere.outer_radius
 /// mu is the cosine of spherical coordinate theta (-1.0 <= mu <= 1.0)
 /// so ray direction in spherical coordinates is [1,acos(mu),0] which needs to be converted to cartesian
 /// Direction of ray, u = [0,sqrt(1-mu*mu),mu]
 /// Center of sphere, c = [0,0,0]
-/// Radius of sphere, r = atmosphere.top_radius
+/// Radius of sphere, r = atmosphere.outer_radius
 /// This function solves the quadratic equation for line-sphere intersection simplified under these assumptions
 fn distance_to_top_atmosphere_boundary(atm: Atmosphere, r: f32, mu: f32) -> f32 {
-  // ignore the case where r > atm.top_radius
-    let positive_discriminant = max(r * r * (mu * mu - 1.0) + atm.top_radius * atm.top_radius, 0.0);
+    // ignore the case where r > atm.outer_radius
+    let positive_discriminant = max(r * r * (mu * mu - 1.0) + atm.outer_radius * atm.outer_radius, 0.0);
     return max(-r * mu + sqrt(positive_discriminant), 0.0);
 }
 
 /// Simplified ray-sphere intersection
 /// as above for intersections with the ground
 fn distance_to_bottom_atmosphere_boundary(r: f32, mu: f32) -> f32 {
-    let positive_discriminant = max(r * r * (mu * mu - 1.0) + atmosphere.bottom_radius * atmosphere.bottom_radius, 0.0);
+    let positive_discriminant = max(r * r * (mu * mu - 1.0) + atmosphere.inner_radius * atmosphere.inner_radius, 0.0);
     return max(-r * mu - sqrt(positive_discriminant), 0.0);
 }
 
 fn ray_intersects_ground(r: f32, mu: f32) -> bool {
-    return mu < 0.0 && r * r * (mu * mu - 1.0) + atmosphere.bottom_radius * atmosphere.bottom_radius >= 0.0;
+    return mu < 0.0 && r * r * (mu * mu - 1.0) + atmosphere.inner_radius * atmosphere.inner_radius >= 0.0;
 }

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -308,7 +308,7 @@ fn max_atmosphere_distance(r: f32, mu: f32) -> f32 {
 /// Returns the observer's position in the atmosphere
 fn get_view_position() -> vec3<f32> {
     let atmo_pos = (atmosphere.world_to_atmosphere * vec4(view.world_position, 1.0)).xyz;
-    return clamp_to_surface(atmosphere, world_pos);
+    return clamp_to_surface(atmosphere, atmo_pos);
 }
 
 // We assume the `up` vector at the view position is the y axis, since the world is locally flat/level.

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -307,7 +307,7 @@ fn max_atmosphere_distance(r: f32, mu: f32) -> f32 {
 
 /// Returns the observer's position in the atmosphere
 fn get_view_position() -> vec3<f32> {
-    let world_pos = (atmosphere.world_to_atmosphere * vec4(view.world_position, 1.0)).xyz;
+    let atmo_pos = (atmosphere.world_to_atmosphere * vec4(view.world_position, 1.0)).xyz;
     return clamp_to_surface(atmosphere, world_pos);
 }
 

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -61,13 +61,13 @@ fn sub_uvs_to_unit(val: vec2<f32>, resolution: vec2<f32>) -> vec2<f32> {
 
 fn multiscattering_lut_r_mu_to_uv(r: f32, mu: f32) -> vec2<f32> {
     let u = 0.5 + 0.5 * mu;
-    let v = saturate((r - atmosphere.bottom_radius) / (atmosphere.top_radius - atmosphere.bottom_radius)); //TODO
+    let v = saturate((r - atmosphere.inner_radius) / (atmosphere.outer_radius - atmosphere.inner_radius)); //TODO
     return unit_to_sub_uvs(vec2(u, v), vec2<f32>(settings.multiscattering_lut_size));
 }
 
 fn multiscattering_lut_uv_to_r_mu(uv: vec2<f32>) -> vec2<f32> {
     let adj_uv = sub_uvs_to_unit(uv, vec2<f32>(settings.multiscattering_lut_size));
-    let r = mix(atmosphere.bottom_radius, atmosphere.top_radius, adj_uv.y);
+    let r = mix(atmosphere.inner_radius, atmosphere.outer_radius, adj_uv.y);
     let mu = adj_uv.x * 2 - 1;
     return vec2(r, mu);
 }
@@ -75,7 +75,7 @@ fn multiscattering_lut_uv_to_r_mu(uv: vec2<f32>) -> vec2<f32> {
 fn sky_view_lut_r_mu_azimuth_to_uv(r: f32, mu: f32, azimuth: f32) -> vec2<f32> {
     let u = (azimuth * FRAC_2_PI) + 0.5;
 
-    let v_horizon = sqrt(r * r - atmosphere.bottom_radius * atmosphere.bottom_radius);
+    let v_horizon = sqrt(r * r - atmosphere.inner_radius * atmosphere.inner_radius);
     let cos_beta = v_horizon / r;
     // Using fast_acos_4 for better precision at small angles
     // to avoid artifacts at the horizon
@@ -99,7 +99,7 @@ fn sky_view_lut_uv_to_zenith_azimuth(r: f32, uv: vec2<f32>) -> vec2<f32> {
     let azimuth = (adj_uv.x - 0.5) * PI_2;
 
     // Horizon parameters
-    let v_horizon = sqrt(r * r - atmosphere.bottom_radius * atmosphere.bottom_radius);
+    let v_horizon = sqrt(r * r - atmosphere.inner_radius * atmosphere.inner_radius);
     let cos_beta = v_horizon / r;
     let beta = fast_acos_4(cos_beta);
     let horizon_zenith = PI - beta;
@@ -192,7 +192,7 @@ const SCATTERING_DENSITY: f32 = 1.0;
 // while calling with `component = 1.0` will return the atmosphere's scattering density.
 fn sample_density_lut(r: f32, component: f32) -> vec3<f32> {
     // sampler clamps to [0, 1] anyways, no need to clamp the altitude
-    let normalized_altitude = (r - atmosphere.bottom_radius) / (atmosphere.top_radius - atmosphere.bottom_radius);
+    let normalized_altitude = (r - atmosphere.inner_radius) / (atmosphere.outer_radius - atmosphere.inner_radius);
     let uv = vec2(1.0 - normalized_altitude, component);
     return textureSampleLevel(medium_density_lut, medium_sampler, uv, 0.0).xyz;
 }
@@ -202,7 +202,7 @@ fn sample_density_lut(r: f32, component: f32) -> vec3<f32> {
 // Nonlinear phase mapping to mitigate banding in low-resolution LUTs.
 const PHASE_MAPPING_N: f32 = 0.5;
 fn sample_scattering_lut(r: f32, neg_LdotV: f32) -> vec3<f32> {
-    let normalized_altitude = (r - atmosphere.bottom_radius) / (atmosphere.top_radius - atmosphere.bottom_radius);
+    let normalized_altitude = (r - atmosphere.inner_radius) / (atmosphere.outer_radius - atmosphere.inner_radius);
     let phase_uv = 0.5 + 0.5 * sign(neg_LdotV) * (1.0 - pow(1.0 - abs(neg_LdotV), PHASE_MAPPING_N));
     let uv = vec2(1.0 - normalized_altitude, phase_uv);
     return textureSampleLevel(medium_scattering_lut, medium_sampler, uv, 0.0).xyz;
@@ -262,10 +262,10 @@ fn sample_sun_radiance(ray_dir_ws: vec3<f32>) -> vec3<f32> {
 }
 
 fn calculate_visible_sun_ratio(atmosphere: Atmosphere, r: f32, mu: f32, sun_angular_size: f32) -> f32 {
-    let bottom_radius = atmosphere.bottom_radius;
+    let inner_radius = atmosphere.inner_radius;
     // Calculate the angle between horizon and sun center
     // Invert the horizon angle calculation to fix shading direction
-    let horizon_cos = -sqrt(1.0 - (bottom_radius * bottom_radius) / (r * r));
+    let horizon_cos = -sqrt(1.0 - (inner_radius * inner_radius) / (r * r));
     let horizon_angle = fast_acos_4(horizon_cos);
     let sun_zenith_angle = fast_acos_4(mu);
     
@@ -289,7 +289,7 @@ fn calculate_visible_sun_ratio(atmosphere: Atmosphere, r: f32, mu: f32, sun_angu
 
 /// Clamp a position to the planet surface (with a small epsilon) to avoid underground artifacts.
 fn clamp_to_surface(atmosphere: Atmosphere, position: vec3<f32>) -> vec3<f32> {
-    let min_radius = atmosphere.bottom_radius + EPSILON;
+    let min_radius = atmosphere.inner_radius + EPSILON;
     let r = length(position);
     if r < min_radius {
         let up = normalize(position);
@@ -388,16 +388,16 @@ struct RaymarchSegment {
 
 fn get_raymarch_segment(r: f32, mu: f32) -> RaymarchSegment {
     // Get both intersection points with atmosphere
-    let atmosphere_intersections = ray_sphere_intersect(r, mu, atmosphere.top_radius);
-    let ground_intersections = ray_sphere_intersect(r, mu, atmosphere.bottom_radius);
+    let atmosphere_intersections = ray_sphere_intersect(r, mu, atmosphere.outer_radius);
+    let ground_intersections = ray_sphere_intersect(r, mu, atmosphere.inner_radius);
 
     var segment: RaymarchSegment;
 
-    if r < atmosphere.bottom_radius {
+    if r < atmosphere.inner_radius {
         // Inside planet - start from bottom of atmosphere
         segment.start = ground_intersections.y; // Use second intersection point with ground
         segment.end = atmosphere_intersections.y;
-    } else if r < atmosphere.top_radius {
+    } else if r < atmosphere.outer_radius {
         // Inside atmosphere
         segment.start = 0.0;
         segment.end = select(atmosphere_intersections.y, ground_intersections.x, ray_intersects_ground(r, mu));

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -153,8 +153,11 @@ fn sample_sky_view_lut(r: f32, ray_dir_as: vec3<f32>) -> vec3<f32> {
 
 fn ndc_to_camera_dist(ndc: vec3<f32>) -> f32 {
     let view_pos = view.view_from_clip * vec4(ndc, 1.0);
-    let t = length(view_pos.xyz / view_pos.w) * settings.scene_units_to_m;
-    return t;
+    let p_view = view_pos.xyz / view_pos.w;
+    let p_world = (view.world_from_view * vec4(p_view, 1.0)).xyz;
+    let p_atmo = (atmosphere.world_to_atmosphere * vec4(p_world, 1.0)).xyz;
+    let cam_atmo = (atmosphere.world_to_atmosphere * vec4(view.world_position, 1.0)).xyz;
+    return length(p_atmo - cam_atmo);
 }
 
 // RGB channels: total inscattered light along the camera ray to the current sample.
@@ -304,7 +307,7 @@ fn max_atmosphere_distance(r: f32, mu: f32) -> f32 {
 
 /// Returns the observer's position in the atmosphere
 fn get_view_position() -> vec3<f32> {
-    var world_pos = view.world_position * settings.scene_units_to_m + vec3(0.0, atmosphere.bottom_radius, 0.0);
+    let world_pos = (atmosphere.world_to_atmosphere * vec4(view.world_position, 1.0)).xyz;
     return clamp_to_surface(atmosphere, world_pos);
 }
 

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -10,7 +10,7 @@
 //! account the directional light color and direction.
 //!
 //! To add the atmosphere to your scene, spawn an entity with the [`Atmosphere`] component and
-//! [`Transform`](bevy_transform::components::Transform), and add [`AtmosphereSettings`] and [`Hdr`] to each
+//! [`Transform`](bevy_transform::components::Transform), and add [`AtmosphereSettings`]
 //! 3D camera that should render it. Detailed documentation is on the [`Atmosphere`] component.
 //!
 //! Placement and scene scale come from the entity's transform. With several atmospheres in one

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -10,7 +10,7 @@
 //! account the directional light color and direction.
 //!
 //! To add the atmosphere to your scene, spawn an entity with the [`Atmosphere`] component and
-//! [`GlobalTransform`](bevy_transform::components::GlobalTransform), and add [`AtmosphereSettings`]
+//! [`bevy_transform::components::GlobalTransform`], and add [`AtmosphereSettings`] to each
 //! 3D camera that should render it. Detailed documentation is on the [`Atmosphere`] component.
 //!
 //! Placement and scene scale come from the entity's transform. With several atmospheres in one

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -9,9 +9,10 @@
 //! to distance fog, but more complex) is handled as well, and takes into
 //! account the directional light color and direction.
 //!
-//! Adding the [`Atmosphere`] component to a 3d camera will enable the effect,
-//! which by default is set to look similar to Earth's atmosphere. See the
-//! documentation on the component itself for information regarding its fields.
+//! Spawn an [`Atmosphere`] on an entity with [`GlobalTransform`](bevy_transform::GlobalTransform),
+//! and add [`AtmosphereSettings`] and [`Hdr`] on each 3d camera that should render it. [`Atmosphere`]
+//! holds radii and medium data; placement and scene scale come from the entity's transform. If several
+//! atmospheres exist, each camera uses the one whose origin is nearest in world space.
 //!
 //! Performance-wise, the effect should be fairly cheap since the LUTs (Look
 //! Up Tables) that encode most of the data are small, and take advantage of the
@@ -39,34 +40,35 @@ pub mod resources;
 
 use bevy_app::{App, Plugin, Update};
 use bevy_asset::{embedded_asset, AssetId};
-use bevy_camera::Camera3d;
+use bevy_camera::{Camera3d, Hdr};
 use bevy_core_pipeline::{
     core_3d::{main_opaque_pass_3d, main_transparent_pass_3d},
     schedule::{Core3d, Core3dSystems},
 };
 use bevy_ecs::{
     component::Component,
-    query::{Changed, QueryItem, With},
+    entity::Entity,
+    query::{Changed, With},
     schedule::IntoScheduleConfigs,
-    system::{lifetimeless::Read, Commands, Local, Query},
+    system::{Commands, Query},
 };
 use bevy_light::{atmosphere::ScatteringMedium, Atmosphere};
-use bevy_math::{UVec2, UVec3, Vec3};
+use bevy_math::{Mat4, UVec2, UVec3, Vec3};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
-    extract_component::UniformComponentPlugin,
+    extract_component::{ExtractComponentPlugin, UniformComponentPlugin},
     render_resource::{DownlevelFlags, ShaderType, SpecializedRenderPipelines},
     renderer::RenderDevice,
-    sync_component::SyncComponent,
+    sync_component::{SyncComponent, SyncComponentPlugin},
     sync_world::RenderEntity,
     Extract, ExtractSchedule, RenderStartup,
 };
 use bevy_render::{
-    extract_component::{ExtractComponent, ExtractComponentPlugin},
     render_resource::{TextureFormat, TextureUsages},
     renderer::RenderAdapter,
     GpuResourceAppExt, Render, RenderApp, RenderSystems,
 };
+use bevy_transform::components::GlobalTransform;
 
 use bevy_shader::load_shader_library;
 use environment::{
@@ -106,12 +108,11 @@ impl Plugin for AtmospherePlugin {
         embedded_asset!(app, "environment.wgsl");
 
         app.add_plugins((
-            ExtractComponentPlugin::<GpuAtmosphereSettings>::default(),
             ExtractComponentPlugin::<AtmosphereEnvironmentMap>::default(),
+            SyncComponentPlugin::<AtmosphereSettings>::default(),
             UniformComponentPlugin::<GpuAtmosphere>::default(),
             UniformComponentPlugin::<GpuAtmosphereSettings>::default(),
         ))
-        .register_required_components::<Atmosphere, AtmosphereSettings>()
         .add_systems(Update, prepare_atmosphere_probe_components);
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
@@ -202,27 +203,53 @@ impl Plugin for AtmospherePlugin {
     }
 }
 
-// This is needed because of the orphan rule not allowing implementing
-// foreign trait ExtractComponent on foreign type Atmosphere
+/// For each camera with [`AtmosphereSettings`], picks the nearest [`Atmosphere`] by world-space
+/// distance to its origin, copies it as [`ExtractedAtmosphere`], and builds [`GpuAtmosphereSettings`].
 pub fn extract_atmosphere(
     mut commands: Commands,
-    mut previous_len: Local<usize>,
-    query: Extract<Query<(RenderEntity, &Atmosphere), With<Camera3d>>>,
+    atmosphere_entities: Extract<Query<(Entity, &Atmosphere, &GlobalTransform)>>,
+    cameras: Extract<Query<(RenderEntity, &AtmosphereSettings, &GlobalTransform), With<Camera3d>>>,
 ) {
-    let mut values = Vec::with_capacity(*previous_len);
-    for (entity, item) in &query {
-        values.push((
-            entity,
-            ExtractedAtmosphere {
-                bottom_radius: item.bottom_radius,
-                top_radius: item.top_radius,
-                ground_albedo: item.ground_albedo,
-                medium: item.medium.id(),
-            },
-        ));
+    let candidates: Vec<(Entity, &Atmosphere, &GlobalTransform)> =
+        atmosphere_entities.iter().collect();
+
+    if candidates.is_empty() {
+        for (render_entity, ..) in &cameras {
+            commands
+                .entity(render_entity)
+                .remove::<ExtractedAtmosphere>();
+            commands
+                .entity(render_entity)
+                .remove::<GpuAtmosphereSettings>();
+        }
+        return;
     }
-    *previous_len = values.len();
-    commands.try_insert_batch(values);
+
+    for (render_entity, settings, cam_global) in &cameras {
+        let cam_world = cam_global.translation();
+        let selected = candidates
+            .iter()
+            .min_by(|(ea, _, gt_a), (eb, _, gt_b)| {
+                let da = cam_world.distance(gt_a.translation());
+                let db = cam_world.distance(gt_b.translation());
+                da.total_cmp(&db).then_with(|| ea.cmp(eb))
+            })
+            .expect("checked non-empty above");
+        let atmo = selected.1;
+        let gt = selected.2;
+
+        let extracted = ExtractedAtmosphere {
+            bottom_radius: atmo.bottom_radius,
+            top_radius: atmo.top_radius,
+            ground_albedo: atmo.ground_albedo,
+            medium: atmo.medium.id(),
+            world_to_atmosphere: gt.to_matrix().inverse(),
+        };
+        commands.entity(render_entity).insert(extracted);
+        commands
+            .entity(render_entity)
+            .insert(GpuAtmosphereSettings::from(settings.clone()));
+    }
 }
 
 /// The render-world representation of an `Atmosphere`, but which
@@ -233,6 +260,7 @@ pub struct ExtractedAtmosphere {
     pub top_radius: f32,
     pub ground_albedo: Vec3,
     pub medium: AssetId<ScatteringMedium>,
+    pub world_to_atmosphere: Mat4,
 }
 
 /// This component controls the resolution of the atmosphere LUTs, and
@@ -255,6 +283,7 @@ pub struct ExtractedAtmosphere {
 /// transmittance to that point (A channel).
 #[derive(Clone, Component, Reflect)]
 #[reflect(Clone, Default)]
+#[require(Hdr)]
 pub struct AtmosphereSettings {
     /// The size of the transmittance LUT
     pub transmittance_lut_size: UVec2,
@@ -296,10 +325,6 @@ pub struct AtmosphereSettings {
     /// units: m
     pub aerial_view_lut_max_distance: f32,
 
-    /// A conversion factor between scene units and meters, used to
-    /// ensure correctness at different length scales.
-    pub scene_units_to_m: f32,
-
     /// The number of points to sample for each fragment when the using
     /// ray marching to render the sky
     pub sky_max_samples: u32,
@@ -321,7 +346,6 @@ impl Default for AtmosphereSettings {
             aerial_view_lut_size: UVec3::new(32, 32, 32),
             aerial_view_lut_samples: 10,
             aerial_view_lut_max_distance: 3.2e4,
-            scene_units_to_m: 1.0,
             sky_max_samples: 16,
             rendering_method: AtmosphereMode::LookupTexture,
         }
@@ -341,7 +365,6 @@ pub struct GpuAtmosphereSettings {
     pub sky_view_lut_samples: u32,
     pub aerial_view_lut_samples: u32,
     pub aerial_view_lut_max_distance: f32,
-    pub scene_units_to_m: f32,
     pub sky_max_samples: u32,
     pub rendering_method: u32,
 }
@@ -365,25 +388,14 @@ impl From<AtmosphereSettings> for GpuAtmosphereSettings {
             sky_view_lut_samples: s.sky_view_lut_samples,
             aerial_view_lut_samples: s.aerial_view_lut_samples,
             aerial_view_lut_max_distance: s.aerial_view_lut_max_distance,
-            scene_units_to_m: s.scene_units_to_m,
             sky_max_samples: s.sky_max_samples,
             rendering_method: s.rendering_method as u32,
         }
     }
 }
 
-impl SyncComponent for GpuAtmosphereSettings {
-    type Target = Self;
-}
-
-impl ExtractComponent for GpuAtmosphereSettings {
-    type QueryData = Read<AtmosphereSettings>;
-    type QueryFilter = (With<Camera3d>, With<Atmosphere>);
-    type Out = Self;
-
-    fn extract_component(item: QueryItem<'_, '_, Self::QueryData>) -> Option<Self::Out> {
-        Some(item.clone().into())
-    }
+impl SyncComponent for AtmosphereSettings {
+    type Target = GpuAtmosphereSettings;
 }
 
 fn configure_camera_depth_usages(

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -241,8 +241,8 @@ pub fn extract_atmosphere(
         let gt = selected.2;
 
         let extracted = ExtractedAtmosphere {
-            bottom_radius: atmo.bottom_radius,
-            top_radius: atmo.top_radius,
+            inner_radius: atmo.inner_radius,
+            outer_radius: atmo.outer_radius,
             ground_albedo: atmo.ground_albedo,
             medium: atmo.medium.id(),
             world_to_atmosphere: gt.to_matrix().inverse(),
@@ -258,8 +258,8 @@ pub fn extract_atmosphere(
 /// hasn't been converted into shader uniforms yet.
 #[derive(Clone, Component)]
 pub struct ExtractedAtmosphere {
-    pub bottom_radius: f32,
-    pub top_radius: f32,
+    pub inner_radius: f32,
+    pub outer_radius: f32,
     pub ground_albedo: Vec3,
     pub medium: AssetId<ScatteringMedium>,
     pub world_to_atmosphere: Mat4,

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -10,7 +10,7 @@
 //! account the directional light color and direction.
 //!
 //! To add the atmosphere to your scene, spawn an entity with the [`Atmosphere`] component and
-//! [`Transform`](bevy_transform::components::Transform), and add [`AtmosphereSettings`]
+//! [`GlobalTransform`](bevy_transform::components::GlobalTransform), and add [`AtmosphereSettings`]
 //! 3D camera that should render it. Detailed documentation is on the [`Atmosphere`] component.
 //!
 //! Placement and scene scale come from the entity's transform. With several atmospheres in one

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -9,10 +9,12 @@
 //! to distance fog, but more complex) is handled as well, and takes into
 //! account the directional light color and direction.
 //!
-//! Spawn an [`Atmosphere`] on an entity with [`GlobalTransform`](bevy_transform::GlobalTransform),
-//! and add [`AtmosphereSettings`] and [`Hdr`] on each 3d camera that should render it. [`Atmosphere`]
-//! holds radii and medium data; placement and scene scale come from the entity's transform. If several
-//! atmospheres exist, each camera uses the one whose origin is nearest in world space.
+//! To add the atmosphere to your scene, spawn an entity with the [`Atmosphere`] component and
+//! [`Transform`](bevy_transform::components::Transform), and add [`AtmosphereSettings`] and [`Hdr`] to each
+//! 3D camera that should render it. Detailed documentation is on the [`Atmosphere`] component.
+//!
+//! Placement and scene scale come from the entity's transform. With several atmospheres in one
+//! scene, each camera picks the atmosphere whose origin is closest in world space.
 //!
 //! Performance-wise, the effect should be fairly cheap since the LUTs (Look
 //! Up Tables) that encode most of the data are small, and take advantage of the

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -477,8 +477,8 @@ struct ScatteringMediumMissingError(AssetId<ScatteringMedium>);
 pub struct GpuAtmosphere {
     //TODO: rename to Planet later?
     pub ground_albedo: Vec3,
-    pub bottom_radius: f32,
-    pub top_radius: f32,
+    pub inner_radius: f32,
+    pub outer_radius: f32,
     pub world_to_atmosphere: Mat4,
 }
 
@@ -489,8 +489,8 @@ pub fn prepare_atmosphere_uniforms(
     for (entity, atmosphere) in atmospheres {
         commands.entity(entity).insert(GpuAtmosphere {
             ground_albedo: atmosphere.ground_albedo,
-            bottom_radius: atmosphere.bottom_radius,
-            top_radius: atmosphere.top_radius,
+            inner_radius: atmosphere.inner_radius,
+            outer_radius: atmosphere.outer_radius,
             world_to_atmosphere: atmosphere.world_to_atmosphere,
         });
     }
@@ -796,8 +796,8 @@ pub fn init_atmosphere_buffer(mut commands: Commands) {
     commands.insert_resource(AtmosphereBuffer {
         buffer: StorageBuffer::from(GpuAtmosphere {
             ground_albedo: Vec3::ZERO,
-            bottom_radius: 0.0,
-            top_radius: 0.0,
+            inner_radius: 0.0,
+            outer_radius: 0.0,
             world_to_atmosphere: Mat4::IDENTITY,
         }),
     });

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -539,7 +539,6 @@ pub(super) fn prepare_atmosphere_transforms(
             Entity,
             &ExtractedView,
             &GpuAtmosphere,
-            &GpuAtmosphereSettings,
         ),
         (With<ExtractedAtmosphere>, With<Camera3d>),
     >,
@@ -557,7 +556,7 @@ pub(super) fn prepare_atmosphere_transforms(
         return;
     };
 
-    for (entity, view, gpu_atmosphere, _settings) in &views {
+    for (entity, view, gpu_atmosphere) in &views {
         // Camera position in atmosphere space
         let cam_world = view.world_from_view.translation();
         let cam_pos = Vec3A::from(

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -479,6 +479,7 @@ pub struct GpuAtmosphere {
     pub ground_albedo: Vec3,
     pub bottom_radius: f32,
     pub top_radius: f32,
+    pub world_to_atmosphere: Mat4,
 }
 
 pub fn prepare_atmosphere_uniforms(
@@ -490,6 +491,7 @@ pub fn prepare_atmosphere_uniforms(
             ground_albedo: atmosphere.ground_albedo,
             bottom_radius: atmosphere.bottom_radius,
             top_radius: atmosphere.top_radius,
+            world_to_atmosphere: atmosphere.world_to_atmosphere,
         });
     }
     Ok(())
@@ -536,7 +538,7 @@ pub(super) fn prepare_atmosphere_transforms(
         (
             Entity,
             &ExtractedView,
-            &ExtractedAtmosphere,
+            &GpuAtmosphere,
             &GpuAtmosphereSettings,
         ),
         (With<ExtractedAtmosphere>, With<Camera3d>),
@@ -555,11 +557,13 @@ pub(super) fn prepare_atmosphere_transforms(
         return;
     };
 
-    for (entity, view, atmosphere, settings) in &views {
+    for (entity, view, gpu_atmosphere, _settings) in &views {
         // Camera position in atmosphere space
+        let cam_world = view.world_from_view.translation();
         let cam_pos = Vec3A::from(
-            view.world_from_view.translation() * settings.scene_units_to_m
-                + Vec3::new(0.0, atmosphere.bottom_radius, 0.0),
+            gpu_atmosphere
+                .world_to_atmosphere
+                .transform_point3(cam_world),
         );
 
         // Up is the local planet surface normal.
@@ -793,44 +797,32 @@ pub(super) fn prepare_atmosphere_bind_groups(
     Ok(())
 }
 
-#[derive(ShaderType)]
-#[repr(C)]
-pub(crate) struct AtmosphereData {
-    pub atmosphere: GpuAtmosphere,
-    pub settings: GpuAtmosphereSettings,
-}
-
 pub fn init_atmosphere_buffer(mut commands: Commands) {
     commands.insert_resource(AtmosphereBuffer {
-        buffer: StorageBuffer::from(AtmosphereData {
-            atmosphere: GpuAtmosphere {
-                ground_albedo: Vec3::ZERO,
-                bottom_radius: 0.0,
-                top_radius: 0.0,
-            },
-            settings: GpuAtmosphereSettings::default(),
+        buffer: StorageBuffer::from(GpuAtmosphere {
+            ground_albedo: Vec3::ZERO,
+            bottom_radius: 0.0,
+            top_radius: 0.0,
+            world_to_atmosphere: Mat4::IDENTITY,
         }),
     });
 }
 
 #[derive(Resource)]
 pub struct AtmosphereBuffer {
-    pub(crate) buffer: StorageBuffer<AtmosphereData>,
+    pub(crate) buffer: StorageBuffer<GpuAtmosphere>,
 }
 
 pub(crate) fn write_atmosphere_buffer(
     device: Res<RenderDevice>,
     queue: Res<RenderQueue>,
-    atmosphere_entity: Query<(&GpuAtmosphere, &GpuAtmosphereSettings), With<Camera3d>>,
+    atmosphere_entity: Query<&GpuAtmosphere, With<Camera3d>>,
     mut atmosphere_buffer: ResMut<AtmosphereBuffer>,
 ) {
-    let Ok((atmosphere, settings)) = atmosphere_entity.single() else {
+    let Ok(atmosphere) = atmosphere_entity.single() else {
         return;
     };
 
-    atmosphere_buffer.buffer.set(AtmosphereData {
-        atmosphere: atmosphere.clone(),
-        settings: settings.clone(),
-    });
+    atmosphere_buffer.buffer.set(atmosphere.clone());
     atmosphere_buffer.buffer.write_buffer(&device, &queue);
 }

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -535,11 +535,7 @@ impl AtmosphereTransformsOffset {
 
 pub(super) fn prepare_atmosphere_transforms(
     views: Query<
-        (
-            Entity,
-            &ExtractedView,
-            &GpuAtmosphere,
-        ),
+        (Entity, &ExtractedView, &GpuAtmosphere),
         (With<ExtractedAtmosphere>, With<Camera3d>),
     >,
     render_device: Res<RenderDevice>,

--- a/crates/bevy_pbr/src/atmosphere/types.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/types.wgsl
@@ -3,9 +3,9 @@
 struct Atmosphere {
     ground_albedo: vec3<f32>,
     // Radius of the planet
-    bottom_radius: f32, // units: m
+    inner_radius: f32, // units: m
     // Radius at which we consider the atmosphere to 'end' for out calculations (from center of planet)
-    top_radius: f32, // units: m
+    outer_radius: f32, // units: m
     // Transform from world space to atmosphere space, inverse of the atmosphere entity's transform
     world_to_atmosphere: mat4x4<f32>,
 }

--- a/crates/bevy_pbr/src/atmosphere/types.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/types.wgsl
@@ -6,6 +6,7 @@ struct Atmosphere {
     bottom_radius: f32, // units: m
     // Radius at which we consider the atmosphere to 'end' for out calculations (from center of planet)
     top_radius: f32, // units: m
+    world_to_atmosphere: mat4x4<f32>,
 }
 
 struct AtmosphereSettings {
@@ -19,7 +20,6 @@ struct AtmosphereSettings {
     sky_view_lut_samples: u32,
     aerial_view_lut_samples: u32,
     aerial_view_lut_max_distance: f32,
-    scene_units_to_m: f32,
     sky_max_samples: u32,
     rendering_method: u32,
 }
@@ -30,9 +30,4 @@ struct AtmosphereSettings {
 struct AtmosphereTransforms {
     world_from_atmosphere: mat4x4<f32>,
     atmosphere_from_world: mat4x4<f32>,
-}
-
-struct AtmosphereData {
-    atmosphere: Atmosphere,
-    settings: AtmosphereSettings,
 }

--- a/crates/bevy_pbr/src/atmosphere/types.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/types.wgsl
@@ -6,6 +6,7 @@ struct Atmosphere {
     bottom_radius: f32, // units: m
     // Radius at which we consider the atmosphere to 'end' for out calculations (from center of planet)
     top_radius: f32, // units: m
+    // Transform from world space to atmosphere space, inverse of the entity's transform
     world_to_atmosphere: mat4x4<f32>,
 }
 

--- a/crates/bevy_pbr/src/atmosphere/types.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/types.wgsl
@@ -6,7 +6,7 @@ struct Atmosphere {
     bottom_radius: f32, // units: m
     // Radius at which we consider the atmosphere to 'end' for out calculations (from center of planet)
     top_radius: f32, // units: m
-    // Transform from world space to atmosphere space, inverse of the entity's transform
+    // Transform from world space to atmosphere space, inverse of the atmosphere entity's transform
     world_to_atmosphere: mat4x4<f32>,
 }
 

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -45,7 +45,7 @@ use crate::{
         self, RenderViewIrradianceVolumeBindGroupEntries, IRRADIANCE_VOLUMES_ARE_USABLE,
     },
     prepass,
-    resources::{AtmosphereBuffer, AtmosphereData, AtmosphereSampler, AtmosphereTextures},
+    resources::{AtmosphereBuffer, AtmosphereSampler, AtmosphereTextures, GpuAtmosphere},
     Bluenoise, EnvironmentMapUniformBuffer, ExtractedAtmosphere, FogMeta,
     GlobalClusterableObjectMeta, GpuClusteredLights, GpuFog, GpuLights, LightMeta,
     LightProbesBuffer, LightProbesUniform, MeshPipeline, MeshPipelineKey, RenderViewLightProbes,
@@ -425,7 +425,7 @@ pub fn layout_entries(
             ),
             (33, sampler(SamplerBindingType::Filtering)),
             // atmosphere data buffer
-            (34, storage_buffer_read_only::<AtmosphereData>(false)),
+            (34, storage_buffer_read_only::<GpuAtmosphere>(false)),
         ));
     }
 

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -1,7 +1,7 @@
 #define_import_path bevy_pbr::mesh_view_bindings
 
 #import bevy_pbr::mesh_view_types as types
-#import bevy_pbr::atmosphere::types as atmosphere
+#import bevy_pbr::atmosphere::types as atmosphere_types
 #import bevy_render::{
     view::View,
     globals::Globals,
@@ -101,7 +101,7 @@ const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: u32 = 64u;
 #ifdef ATMOSPHERE
 @group(0) @binding(32) var atmosphere_transmittance_texture: texture_2d<f32>;
 @group(0) @binding(33) var atmosphere_transmittance_sampler: sampler;
-@group(0) @binding(34) var<storage> atmosphere_data: atmosphere::AtmosphereData;
+@group(0) @binding(34) var<storage> atmosphere: atmosphere_types::Atmosphere;
 #endif // ATMOSPHERE
 #ifdef BLUE_NOISE_TEXTURE
 @group(0) @binding(35) var blue_noise_texture: texture_2d_array<f32>;

--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -911,10 +911,10 @@ color *= (*light).color.rgb * texture_sample;
 
 #ifdef ATMOSPHERE
     let P = (*input).P;
-    let atmosphere = view_bindings::atmosphere_data.atmosphere;
-    let O = vec3(0.0, atmosphere.bottom_radius, 0.0);
-    let P_scaled = P * vec3(view_bindings::atmosphere_data.settings.scene_units_to_m);
-    let P_as = P_scaled + O;
+    let atmosphere = view_bindings::atmosphere;
+    let P_as = (
+        view_bindings::atmosphere.world_to_atmosphere * vec4(P, 1.0)
+    ).xyz;
     let P_clamped = clamp_to_surface(atmosphere, P_as);
     let r = length(P_clamped);
     let local_up = normalize(P_clamped);
@@ -933,7 +933,7 @@ color *= (*light).color.rgb * texture_sample;
 
 #ifdef ATMOSPHERE
 fn sample_transmittance_lut(r: f32, mu: f32) -> vec3<f32> {
-    let uv = transmittance_lut_r_mu_to_uv(view_bindings::atmosphere_data.atmosphere, r, mu);
+    let uv = transmittance_lut_r_mu_to_uv(view_bindings::atmosphere, r, mu);
     return textureSampleLevel(
         view_bindings::atmosphere_transmittance_texture, 
         view_bindings::atmosphere_transmittance_sampler, uv, 0.0).rgb;

--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
@@ -21,7 +21,7 @@
 #import bevy_pbr::mesh_functions::{get_world_from_local, mesh_position_local_to_clip}
 #import bevy_pbr::mesh_view_bindings::{
     globals, lights, view, clustered_lights,
-    atmosphere_data, atmosphere_transmittance_texture, atmosphere_transmittance_sampler
+    atmosphere, atmosphere_transmittance_texture, atmosphere_transmittance_sampler
 }
 #import bevy_pbr::mesh_view_types::{
     DIRECTIONAL_LIGHT_FLAGS_VOLUMETRIC_BIT,
@@ -311,16 +311,14 @@ fn fragment(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
 #ifdef ATMOSPHERE
                 // attenuate by atmospheric scattering
                 let P = P_world + depth_offset;
-                let P_scaled = P * vec3(atmosphere_data.settings.scene_units_to_m);
-                let O = vec3(0.0, atmosphere_data.atmosphere.bottom_radius, 0.0);
-                let P_as = P_scaled + O;
-                let P_clamped = clamp_to_surface(atmosphere_data.atmosphere, P_as);
+                let P_as = (atmosphere.world_to_atmosphere * vec4(P, 1.0)).xyz;
+                let P_clamped = clamp_to_surface(atmosphere, P_as);
                 let r = length(P_clamped);
                 let local_up = normalize(P_clamped);
                 let mu_light = dot(L, local_up);
 
                 let transmittance = sample_transmittance_lut(r, mu_light);
-                let sun_visibility = calculate_visible_sun_ratio(atmosphere_data.atmosphere, r, mu_light, (*light).sun_disk_angular_size);
+                let sun_visibility = calculate_visible_sun_ratio(atmosphere, r, mu_light, (*light).sun_disk_angular_size);
                 light_factors_per_step *= transmittance * sun_visibility;
 #endif
 
@@ -518,7 +516,7 @@ fn fetch_spot_shadow_without_normal(light_id: u32, frag_position: vec4<f32>, fra
 
 #ifdef ATMOSPHERE
 fn sample_transmittance_lut(r: f32, mu: f32) -> vec3<f32> {
-    let uv = transmittance_lut_r_mu_to_uv(atmosphere_data.atmosphere, r, mu);
+    let uv = transmittance_lut_r_mu_to_uv(atmosphere, r, mu);
     return textureSampleLevel(
         atmosphere_transmittance_texture,
         atmosphere_transmittance_sampler, uv, 0.0).rgb;

--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -80,7 +80,7 @@ fn atmosphere_controls(
     if keyboard_input.just_pressed(KeyCode::Digit3) {
         for (mut atmosphere, mut transform) in &mut planet_atmosphere {
             *atmosphere = Atmosphere::earth(atmosphere_presets.earth.clone());
-            transform.translation = -Vec3::Y * atmosphere.bottom_radius;
+            transform.translation = -Vec3::Y * atmosphere.inner_radius;
             println!("Switched to Earth atmosphere");
         }
     }
@@ -88,7 +88,7 @@ fn atmosphere_controls(
     if keyboard_input.just_pressed(KeyCode::Digit4) {
         for (mut atmosphere, mut transform) in &mut planet_atmosphere {
             *atmosphere = Atmosphere::mars(atmosphere_presets.mars.clone());
-            transform.translation = -Vec3::Y * atmosphere.bottom_radius;
+            transform.translation = -Vec3::Y * atmosphere.inner_radius;
             println!("Switched to Mars atmosphere");
         }
     }

--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -6,7 +6,6 @@ use std::f32::consts::PI;
 use bevy::{
     anti_alias::taa::TemporalAntiAliasing,
     camera::Exposure,
-    camera::Hdr,
     color::palettes::css::BLACK,
     core_pipeline::tonemapping::Tonemapping,
     image::{

--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -6,6 +6,7 @@ use std::f32::consts::PI;
 use bevy::{
     anti_alias::taa::TemporalAntiAliasing,
     camera::Exposure,
+    camera::Hdr,
     color::palettes::css::BLACK,
     core_pipeline::tonemapping::Tonemapping,
     image::{
@@ -70,36 +71,38 @@ fn print_controls() {
 
 fn atmosphere_controls(
     keyboard_input: Res<ButtonInput<KeyCode>>,
-    mut atmosphere_settings: Query<&mut AtmosphereSettings>,
-    mut atmosphere_query: Query<&mut Atmosphere>,
+    mut planet_atmosphere: Query<(&mut Atmosphere, &mut Transform)>,
+    mut camera_settings: Query<&mut AtmosphereSettings, With<Camera3d>>,
     atmosphere_presets: Res<AtmospherePresets>,
     mut game_state: ResMut<GameState>,
     mut camera_exposure: Query<&mut Exposure, With<Camera3d>>,
     time: Res<Time>,
 ) {
     if keyboard_input.just_pressed(KeyCode::Digit3) {
-        for mut atmosphere in &mut atmosphere_query {
+        for (mut atmosphere, mut transform) in &mut planet_atmosphere {
             *atmosphere = Atmosphere::earth(atmosphere_presets.earth.clone());
+            transform.translation = -Vec3::Y * atmosphere.bottom_radius;
             println!("Switched to Earth atmosphere");
         }
     }
 
     if keyboard_input.just_pressed(KeyCode::Digit4) {
-        for mut atmosphere in &mut atmosphere_query {
+        for (mut atmosphere, mut transform) in &mut planet_atmosphere {
             *atmosphere = Atmosphere::mars(atmosphere_presets.mars.clone());
+            transform.translation = -Vec3::Y * atmosphere.bottom_radius;
             println!("Switched to Mars atmosphere");
         }
     }
 
     if keyboard_input.just_pressed(KeyCode::Digit1) {
-        for mut settings in &mut atmosphere_settings {
+        for mut settings in &mut camera_settings {
             settings.rendering_method = AtmosphereMode::LookupTexture;
             println!("Switched to lookup texture rendering method");
         }
     }
 
     if keyboard_input.just_pressed(KeyCode::Digit2) {
-        for mut settings in &mut atmosphere_settings {
+        for mut settings in &mut camera_settings {
             settings.rendering_method = AtmosphereMode::Raymarched;
             println!("Switched to raymarched rendering method");
         }
@@ -136,12 +139,14 @@ fn setup_camera_fog(
         mars: mars_medium.clone(),
     });
 
+    // Spawn earth atmosphere
+    commands.spawn(Atmosphere::earth(earth_medium));
+
     commands.spawn((
         Camera3d::default(),
+        Hdr,
         Transform::from_xyz(-2.8, 0.045, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
-        // Earth atmosphere
-        Atmosphere::earth(earth_medium),
-        // Can be adjusted to change the scene scale and rendering quality
+        // Can be adjusted to change the rendering quality
         AtmosphereSettings::default(),
         // The directional light illuminance used in this scene
         // (the one recommended for use with this feature) is

--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -144,7 +144,6 @@ fn setup_camera_fog(
 
     commands.spawn((
         Camera3d::default(),
-        Hdr,
         Transform::from_xyz(-2.8, 0.045, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
         // Can be adjusted to change the rendering quality
         AtmosphereSettings::default(),

--- a/examples/large_scenes/bevy_city/src/main.rs
+++ b/examples/large_scenes/bevy_city/src/main.rs
@@ -85,12 +85,15 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, mut scattering_mediums: ResMut<Assets<ScatteringMedium>>) {
+    commands.spawn(Atmosphere::earth(
+        scattering_mediums.add(ScatteringMedium::default()),
+    ));
+
     commands.spawn((
         Camera3d::default(),
         Hdr,
         Transform::from_xyz(15.0, 10.0, 20.0).looking_at(Vec3::ZERO, Vec3::Y),
         FreeCamera::default(),
-        Atmosphere::earth(scattering_mediums.add(ScatteringMedium::default())),
         AtmosphereSettings::default(),
         // The directional light illuminance used in this scene is
         // quite bright, so raising the exposure compensation helps


### PR DESCRIPTION
**Anecdotal feedback:** 
- no floating origin support for implementing large-scale worlds, forked Bevy's atmosphere at https://github.com/philpax/veldera/blob/main/crates/bevy_pbr_atmosphere_planet/NOTICE.md
- no custom up axis support, resorted to using a custom sky shader for flight simulator with Z up coordinate system. Bevy's atmosphere appears tilted at a 90 degree angle with no way of changing it. 

**Solution:**
- Atmosphere component can be spawned stand-alone
- AtmosphereSettings remains on camera
- A closest-to-camera heuristic is used to pick the primary atmosphere to render. Deliberately no multi-atmosphere support to keep the scope of this PR small and self contained. See https://github.com/mate-h/bevy/pull/19 at an attempt.
- `scene_units_to_m` removed in favor of using `Transform`
- Z up now possible by offsetting the viewer position to the equator
- Floating origin systems now possible
- Simplify the `AtmosphereBuffer` / `AtmosphereData` structs to just use the plain extracted `GpuAtmosphere` struct. this reduces the complexity of the struct in the mesh view bindings. Since atmosphere settings is coupled with the rendering pipeline of the atmosphere this makes sense architecturally.
- We no longer hard code the offset to the north pole from the planet center in places.

**Why not multi atmosphere:**
The atmosphere uses multiple LUTs (lookup textures) to accelerate the rendering performance. Some of them are not view dependent:
- Transmittance LUT
- Multiple scattering LUT
- Scattering / density LUTs

These can be coupled and rendered for each atmosphere individually. However the remainder of the pipeline is view dependent:
- Aerial View LUT
- Sky View LUT
- Render Sky pass

In raymarched rendering mode, these LUTs can be skipped and only the render sky pass runs sampling on all of the atmospheres with a raymarch in screen space. 

Further, the Sky View LUT uses a local reference frame to concentrate texel density along the horizon's local up axis. This in turn means it's coupled with both a _specific_ atmosphere's local coordinates as well as the view's transform matrix. We cannot consider rendering both atmospheres into a single LUT for this reason. So it has to be unique for each pair of (view, atmosphere). Given two views and two atmospheres we would need 4 of these Sky View LUTs and at some point, raymarched rendering will become the less expensive option. 

Lastly the Render Sky pass needs to happen once per view, we cannot realistically composite them in sequence with simple dual-source blending as we do with the scene, this would result in incorrect scattering integration. This in turn means we need to bind ALL of the luts calculated previously so a single render sky pass and render aerial view lut - perhaps making use of array textures. Rely on unified volumetric ingegration in the raymarching loop: for each light,for each atmosphere, attenuate inscattering and transmittance along the path integral. It is suffice to say this change is overall _too complex_ for the time being and is likely the reason Unreal Engine also do not support multiple atmospheres. For context: our research is based heavily on Sebastian Hillarie's work, one of the Unreal graphics engineers.

That being said about multiple atmospheres - I am thinking of this PR as a segway into unified volumetrics in Bevy. that is: Render the FogVolume and Atmosphere in a single pass! Making use of the frustum aligned voxel grid "froxel" approach to accelerate the rendering. This would drastically increase the performance for scenes wanting to make use of both the atmosphere and local fog volumes. 